### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -7,7 +7,7 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 key=$(ynh_string_random --length=32)
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -11,7 +11,7 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone=$(cat /etc/timezone)
+timezone=$(timedatectl show --value --property=Timezone)
 key=$(ynh_string_random --length=32)
 
 password=$YNH_APP_ARG_PASSWORD


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.