### PR TITLE
PHP 8.5 and composer update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 Lightweight CalDAV and CardDAV server
 
-[![Version: 5.4.3~ynh1](https://img.shields.io/badge/Version-5.4.3~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/davis/)
+[![Version: 5.4.3~ynh2](https://img.shields.io/badge/Version-5.4.3~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/davis/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/davis"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Davis"
 description.en = "Lightweight CalDAV and CardDAV server"
 description.fr = "Serveur CalDAV et CardDAV léger"
 
-version = "5.4.3~ynh1"
+version = "5.4.3~ynh2"
 
 maintainers = ["eric_G"]
 
@@ -62,10 +62,10 @@ ram.runtime = "100M"
     main.url = "/"
 
     [resources.apt]
-    packages = "postgresql, php8.4-intl, php8.4-gd, php8.4-pgsql, php8.4-ldap, php8.4-curl, php8.4-dom, php8.4-xml, php8.4-zip"
+    packages = "postgresql, php8.5-intl, php8.5-gd, php8.5-pgsql, php8.5-ldap, php8.5-curl, php8.5-dom, php8.5-xml, php8.5-zip"
 
     [resources.database]
     type = "postgresql"
 
     [resources.composer]
-    version = "2.9.5"
+    version = "2.10.1"


### PR DESCRIPTION
> PHP > 8.2 (with pdo_mysql [or pdo_pgsql, pdo_sqlite], gd and intl extensions), compatible up to PHP 8.5 (See dependencies table below)

See https://github.com/tchapi/davis#-requirements .